### PR TITLE
supported machines: Add section on supported machines

### DIFF
--- a/docs/yocto-project/krogoth.md
+++ b/docs/yocto-project/krogoth.md
@@ -1,0 +1,14 @@
+#Yocto Project 2.1 (Krogoth)
+
+In the version of Yocto Project 2.1 (Krogoth) the following machines are supported:
+
+Commercial name                                 |Machine         |Layer                                                                                              |
+------------------------------------------------|----------------|---------------------------------------------------------------------------------------------------|
+Beaglebone Black                                |beaglebone      |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/krogoth)                   |
+Boundary Devices Nitrogen6X                     |nitrogen6x      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/krogoth)     |
+NXP i.MX6 Dual SABRE Automotive Board           |imx6dlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/krogoth)     |
+NXP i.MX6 Dual SABRE Platform for Smart Devices |imx6dlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/krogoth)     |
+NXP i.MX6 Quad SABRE Automotive Board           |imx6qsabreauto  |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/krogoth)     |
+NXP i.MX6 Quad SABRE Platform for Smart Devices |imx6qsabresd    |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/krogoth)     |
+Raspberry Pi 3 Model B and B+                   |raspberrypi3    |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/krogoth) |
+Wandboard Solo/Dual/Quad                        |wandboard       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/krogoth)     |

--- a/docs/yocto-project/morty.md
+++ b/docs/yocto-project/morty.md
@@ -1,0 +1,14 @@
+#Yocto Project 2.2 (Morty)
+
+In the version of Yocto Project 2.2 (Morty) the following machines are supported:
+
+Commercial name                                 |Machine         |Layer                                                                                            |
+------------------------------------------------|----------------|-------------------------------------------------------------------------------------------------|
+Beaglebone Black                                |beaglebone      |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/morty)                   |
+Boundary Devices Nitrogen6X                     |nitrogen6x      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/morty)     |
+NXP i.MX6 Dual SABRE Platform for Smart Devices |imx6dlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/morty)     |
+NXP i.MX6 Dual SABRE Platform for Smart Devices |imxdlsabresd    |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/morty)     |
+NXP i.MX6 Quad SABRE Automotive Board           |imx6qsabreauto  |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/morty)     |
+NXP i.MX6 Quad SABRE Automotive Board           |imx6qsabresd    |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/morty)     |
+Raspberry Pi 3 Model B and B+                   |raspberrypi3    |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/morty) |
+Wandboard Solo/Dual/Quad                        |wandboard       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/morty)     |

--- a/docs/yocto-project/pyro.md
+++ b/docs/yocto-project/pyro.md
@@ -1,0 +1,15 @@
+#Yocto Project 2.3 (Pyro)
+
+In the version of Yocto Project 2.3 (Pyro) the following machines are supported:
+
+Commercial name                                 |Machine         |Layer                                                                                           |
+------------------------------------------------|----------------|------------------------------------------------------------------------------------------------|
+Beaglebone Black                                |beaglebone      |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/pyro)                   |
+Boundary Devices Nitrogen6X                     |nitrogen6x      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |
+NXP i.MX6 Dual SABRE Automotive Board           |imx6dlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |
+NXP i.MX6 Dual SABRE Platform for Smart Devices |imx6dlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |
+NXP i.MX6 Quad SABRE Automotive Board           |imx6qsabreauto  |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |
+NXP i.MX6 Quad SABRE Platform for Smart Devices |imx6qsabresd    |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |
+Raspberry Pi 3 Model B and B+                   |raspberrypi3    |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/pyro) |
+Toradex Apalis iMX6                             |apalis-imx6     |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |
+Wandboard Solo/Dual/Quad                        |wandboard       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/pyro)     |

--- a/docs/yocto-project/rocko.md
+++ b/docs/yocto-project/rocko.md
@@ -1,0 +1,15 @@
+#Yocto Project 2.4 (Rocko)
+
+In the version of Yocto Project 2.4 (Rocko) the following machines are supported:
+
+Commercial name                            |Machine          |Layer                                                                                            |
+-------------------------------------------|-----------------|-------------------------------------------------------------------------------------------------|
+Beaglebone Black                           |beaglebone       |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/rocko)                   |
+Boundary Devices Nitrogen6X                |nitrogen6x       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |
+Element14 WaRP i.MX7 Solo                  |imx7s-warp       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |
+NXP i.MX6 SABRE Automotive Board           |imx6qdlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |
+NXP i.MX6 SABRE Platform for Smart Devices |imx6qdlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |
+Raspberry Pi 3 Model B and B+              |raspberrypi3     |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/rocko) |
+TechNexion PICO i.MX7                      |imx7d-pico       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |
+Toradex Apalis iMX6                        |apalis-imx6      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |
+Wandboard Solo/Dual/Quad                   |wandboard        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/rocko)     |

--- a/docs/yocto-project/sumo.md
+++ b/docs/yocto-project/sumo.md
@@ -1,0 +1,15 @@
+#Yocto Project 2.5 (Sumo)
+
+In the version of Yocto Project 2.5 (Sumo) the following machines are supported:
+
+Commercial name                            |Machine          |Layer                                                                                           |
+-------------------------------------------|-----------------|------------------------------------------------------------------------------------------------|
+Beaglebone Black                           |beaglebone       |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/sumo)                   |
+Boundary Devices Nitrogen6X                |nitrogen6x       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |
+Element14 WaRP i.MX7 Solo                  |imx7s-warp       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |
+NXP i.MX6 SABRE Automotive Board           |imx6qdlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |
+NXP i.MX6 SABRE Platform for Smart Devices |imx6qdlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |
+Raspberry Pi 3 Model B and B+              |raspberrypi3     |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/sumo) |
+TechNexion PICO i.MX7                      |imx7d-pico       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |
+Toradex Apalis iMX6                        |apalis-imx6      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |
+Wandboard Solo/Dual/Quad                   |wandboard        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/sumo)     |

--- a/docs/yocto-project/supported-machines.md
+++ b/docs/yocto-project/supported-machines.md
@@ -1,0 +1,48 @@
+The UpdateHub support multiple Yocto Project releases and the
+latest Yocto Project release we offer support for is the 3.1
+LTS (dunfell).
+
+!!! danger ""
+    If you need to use an Yocto Project release different than
+    the 3.1 LTS (dunfell) release please refer to the respective
+    layers to check for compatibility.
+
+Manufacturer    |Repository                                                                                                                 |
+----------------|---------------------------------------------------------------------------------------------------------------------------|
+Freescale       |[https://github.com/UpdateHub/meta-updatehub-freescale.git](https://github.com/UpdateHub/meta-updatehub-freescale.git)     |
+RaspberryPi     |[https://github.com/UpdateHub/meta-updatehub-raspberrypi.git](https://github.com/UpdateHub/meta-updatehub-raspberrypi.git) |
+Texas Intruments|[https://github.com/UpdateHub/meta-updatehub-ti.git](https://github.com/UpdateHub/meta-updatehub-ti.git)                   |
+
+UpdateHub has support for the machines specified in the table
+below. Remember that it is possible for other configurations to
+work correctly with UpdateHub, the machines that have been
+configured and tested are the ones informed here.
+
+Commercial name                            |Machine           |Layer                                                                                              |
+-------------------------------------------|------------------|---------------------------------------------------------------------------------------------------|
+Beaglebone Black                           |beaglebone        |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/dunfell)                   |
+Boundary Devices Nitrogen6X                |nitrogen6x        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+Element14 WaRP i.MX7 Solo                  |imx7s-warp        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+NXP i.MX6 SABRE Automotive Board           |imx6qdlsabreauto  |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+NXP i.MX6 SABRE Platform for Smart Devices |imx6qdlsabresd    |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+Raspberry Pi 3 Model B and B+              |raspberrypi3      |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/dunfell) |
+Raspberry Pi 4 Model B                     |raspberrypi4      |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/dunfell) |
+TechNexion PICO i.MX7                      |imx7d-pico        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+Toradex Apalis iMX6                        |apalis-imx6       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+Toradex Colibri iMX6                       |colibri-imx6      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+Toradex Colibri iMX7 (with eMMC storage)   |colibri-imx7-emmc |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+Wandboard Solo/Dual/Quad                   |wandboard         |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/dunfell)     |
+
+The support for the machines in the table above is from Yocto Project 3.1 (Dunfell), but Updatehub has support for the Yocto Project since version 2.1 (Krogoth).
+In case you are using an older version of the Yocto Project, below you can find the supported versions and the respective machines:
+
+* [Yocto Project 3.0 (Zeus)](zeus.md)
+* [Yocto Project 2.7 (Warrior)](warrior.md)
+* [Yocto Project 2.6 (Thud)](thud.md)
+* [Yocto Project 2.5 (Sumo)](sumo.md)
+* [Yocto Project 2.4 (Rocko)](rocko.md)
+* [Yocto Project 2.3 (Pyro)](pyro.md)
+* [Yocto Project 2.2 (Morty)](morty.md)
+* [Yocto Project 2.1 (Krogoth)](krogoth.md)
+
+If you have any difficulties or doubts, access the [Gitter](https://gitter.im/UpdateHub/community?source=orgpage) so we can help you.

--- a/docs/yocto-project/thud.md
+++ b/docs/yocto-project/thud.md
@@ -1,0 +1,16 @@
+#Yocto Project 2.6 (Thud)
+
+In the version of Yocto Project 2.6 (Thud) the following machines are supported:
+
+Commercial name                            |Machine          |Layer                                                                                           |
+-------------------------------------------|-----------------|------------------------------------------------------------------------------------------------|
+Beaglebone Black                           |beaglebone       |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/thud)                   |
+Boundary Devices Nitrogen6X                |nitrogen6x       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+Element14 WaRP i.MX7 Solo                  |imx7s-warp       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+NXP i.MX6 SABRE Automotive Board           |imx6qdlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+NXP i.MX6 SABRE Platform for Smart Devices |imx6qdlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+Raspberry Pi 3 Model B and B+              |raspberrypi3     |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/thud) |
+TechNexion PICO i.MX7                      |imx7d-pico       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+Toradex Apalis iMX6                        |apalis-imx6      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+Toradex Colibri iMX6                       |colibri-imx6     |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |
+Wandboard Solo/Dual/Quad                   |wandboard        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/thud)     |

--- a/docs/yocto-project/warrior.md
+++ b/docs/yocto-project/warrior.md
@@ -1,0 +1,16 @@
+#Yocto Project 2.7 (Warrior)
+
+In the version of Yocto Project 2.7 (Warrior) the following machines are supported:
+
+Commercial name                            |Machine          |Layer                                                                                              |
+-------------------------------------------|-----------------|---------------------------------------------------------------------------------------------------|
+Beaglebone Black                           |beaglebone       |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/warrior)                   |
+Boundary Devices Nitrogen6X                |nitrogen6x       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+Element14 WaRP i.MX7 Solo                  |imx7s-warp       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+NXP i.MX6 SABRE Automotive Board           |imx6qdlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+NXP i.MX6 SABRE Platform for Smart Devices |imx6qdlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+Raspberry Pi 3 Model B and B+              |raspberrypi3     |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/warrior) |
+TechNexion PICO i.MX7                      |imx7d-pico       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+Toradex Apalis iMX6                        |apalis-imx6      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+Toradex Colibri iMX6                       |colibri-imx6     |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |
+Wandboard Solo/Dual/Quad                   |wandboard        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/warrior)     |

--- a/docs/yocto-project/zeus.md
+++ b/docs/yocto-project/zeus.md
@@ -1,0 +1,17 @@
+#Yocto Project 3.0 (Zeus)
+
+In the version of Yocto Project 3.0 (Zeus) the following machines are supported:
+
+Commercial name                            |Machine          |Layer                                                                                           |
+-------------------------------------------|-----------------|------------------------------------------------------------------------------------------------|
+Beaglebone Black                           |beaglebone       |[meta-updatehub-ti](https://github.com/UpdateHub/meta-updatehub-ti/tree/zeus)                   |
+Boundary Devices Nitrogen6X                |nitrogen6x       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+Element14 WaRP i.MX7 Solo                  |imx7s-warp       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+NXP i.MX6 SABRE Automotive Board           |imx6qdlsabreauto |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+NXP i.MX6 SABRE Platform for Smart Devices |imx6qdlsabresd   |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+Raspberry Pi 3 Model B and B+              |raspberrypi3     |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/zeus) |
+Raspberry Pi 4 Model B                     |raspberrypi4     |[meta-updatehub-raspberrypi](https://github.com/UpdateHub/meta-updatehub-raspberrypi/tree/zeus) |
+TechNexion PICO i.MX7                      |imx7d-pico       |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+Toradex Apalis iMX6                        |apalis-imx6      |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+Toradex Colibri iMX6                       |colibri-imx6     |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |
+Wandboard Solo/Dual/Quad                   |wandboard        |[meta-updatehub-freescale](https://github.com/UpdateHub/meta-updatehub-freescale/tree/zeus)     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - Package and Rollout: updatehub-cloud/package-rollout.md
     - Your menu account: updatehub-cloud/menu.md
   - Integrating with Yocto Project:
+    - Supported machines: yocto-project/supported-machines.md
     - Yocto Project guide: yocto-project/yocto-project-guide.md
     - Yocto Project reference: yocto-project/yocto-project-reference.md
     - Glossary of variables: yocto-project/glossary.md


### PR DESCRIPTION
Add supported machines section according to the Yocto Project version,
from 2.1 (Krogoth) to 3.1 (Dunfell).

Signed-off-by: domarys <domaryscorrea@gmail.com>