### PR TITLE
mkdocs: Change 'tabs' declaration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,8 +23,8 @@ theme:
     text: 'Roboto'
     code: 'Roboto Mono'
   logo: 'img/assets/favicon.ico'
-  feature:
-    tabs: true
+  features:
+    - tabs
 
 # Customization
 extra:


### PR DESCRIPTION
The old declaration is not working, changed to the definition used in
mkdock.yml from Mkdocs Material repository. This option put the
sections menu in superior bar

Signed-off-by: domarys <domaryscorrea@gmail.com>